### PR TITLE
Change threshold option from seconds to milliseconds

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -21,7 +21,7 @@ async function main() {
   
   try {
     // There is a minimum limit here of 60 seconds.
-    let idleDetector = new IdleDetector({threshold: 60});
+    let idleDetector = new IdleDetector({threshold: 60000});
     idleDetector.addEventListener('change', e => {
       let {user, screen} = idleDetector.state;
       console.log(`[${new Date().toLocaleString()}] idle change: ${user}, ${screen}`);

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The API design is largely inspired by the [Sensors API](https://w3c.github.io/se
 
 ```js
 dictionary IdleOptions {
-  unsigned long threshold = 60000; /* milliseconds */
+  [EnforceRange] unsigned long threshold = 60000; /* milliseconds */
 };
 
 enum UserIdleState {

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The API design is largely inspired by the [Sensors API](https://w3c.github.io/se
 
 ```js
 dictionary IdleOptions {
-  unsigned long threshold = 60; /* seconds */
+  unsigned long threshold = 60000; /* milliseconds */
 };
 
 enum UserIdleState {
@@ -101,7 +101,7 @@ async function main() {
   console.log("IdleDetector is available! Go idle!");
   
   try {
-    let idleDetector = new IdleDetector({ threshold: 60 });
+    let idleDetector = new IdleDetector({ threshold: 60000 });
     idleDetector.addEventListener('change', () => { 
       console.log(`idle change: ${this.state.user}, ${this.state.screen}`);
     });


### PR DESCRIPTION
According to the [W3C TAG design principles](https://w3ctag.github.io/design-principles/#milliseconds) any web API that accepts a time measurement should do so in milliseconds, even if seconds is more natural.

Fixes #11.