### PR TITLE
Update GitHub Action to ubuntu-latest

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   main:
     name: Build, Validate and Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: w3c/spec-prod@v1


### PR DESCRIPTION
Bikeshed requires Python 3.9, which is not available in Ubuntu 20.04.